### PR TITLE
Make newPivotQuery public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -532,7 +532,7 @@ trait InteractsWithPivotTable
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function newPivotQuery()
+    public function newPivotQuery()
     {
         $query = $this->newPivotStatement();
 


### PR DESCRIPTION
This pull request makes _newPivotQuery_ method as public. This is usefull for example: counting pivot table, getting information from pivot table etc. without querying related table.

Counting:
```php
$post->comments()->newPivotQuery()->count();
```

Counting with condition:
```php
$post->comments()->newPivotQuery()->whereIn('author_id', [1, 2])->count();
```

Checking if exists:
```php
$post->comments()->newPivotQuery()->where('created_at', '>=', Carbon::now()->subDay()->toDateTimeString())->exists();
```